### PR TITLE
Add promises benchmark and repetition parameter

### DIFF
--- a/future.rb
+++ b/future.rb
@@ -8,13 +8,21 @@ def retrieve_all(sites)
   sites.map { |site| [site, HTTParty.get("http://#{site}.com")] }.to_h
 end
 
-def retrieve_all_async(sites)
+def retrieve_all_future(sites)
   sites.map do |site|
     Concurrent::Future.new { [site, HTTParty.get("http://#{site}.com")] }
   end.map(&:execute).map(&:value).to_h
 end
 
+def retrieve_all_promise(sites)
+  sites.map do |site|
+    Concurrent::Promise.new { [site, HTTParty.get("http://#{site}.com")] }
+  end.map(&:execute).map(&:value).to_h
+end
+
+n = ARGV[0].nil? ? 1 : ARGV[0].to_i
 Benchmark.bmbm(7) do |bench|
-  bench.report('sync:') { retrieve_all(sites) }
-  bench.report('async:') { retrieve_all_async(sites) }
+  bench.report('sync:') { n.times { retrieve_all(sites) } }
+  bench.report('future:') { n.times { retrieve_all_future(sites) } }
+  bench.report('promise:') { n.times { retrieve_all_promise(sites) } }
 end

--- a/future.rb
+++ b/future.rb
@@ -4,25 +4,27 @@ require 'benchmark'
 
 sites = %w(cnn facebook google microsoft github)
 
-def retrieve_all(sites)
-  sites.map { |site| [site, HTTParty.get("http://#{site}.com")] }.to_h
+def retrieve_all(sites, n)
+  (sites * n).map do |site|
+    [site, HTTParty.get("http://#{site}.com")]
+  end.to_h
 end
 
-def retrieve_all_future(sites)
-  sites.map do |site|
+def retrieve_all_future(sites, n)
+  (sites * n).map do |site|
     Concurrent::Future.new { [site, HTTParty.get("http://#{site}.com")] }
   end.map(&:execute).map(&:value).to_h
 end
 
-def retrieve_all_promise(sites)
-  sites.map do |site|
+def retrieve_all_promise(sites, n)
+  (sites * n).map do |site|
     Concurrent::Promise.new { [site, HTTParty.get("http://#{site}.com")] }
   end.map(&:execute).map(&:value).to_h
 end
 
 n = ARGV[0].nil? ? 1 : ARGV[0].to_i
 Benchmark.bmbm(7) do |bench|
-  bench.report('sync:') { n.times { retrieve_all(sites) } }
-  bench.report('future:') { n.times { retrieve_all_future(sites) } }
-  bench.report('promise:') { n.times { retrieve_all_promise(sites) } }
+  bench.report('sync:') { retrieve_all(sites, n) }
+  bench.report('future:') { retrieve_all_future(sites, n) }
+  bench.report('promise:') { retrieve_all_promise(sites, n) }
 end


### PR DESCRIPTION
Passing 5 or even 3 as a command line argument to future.rb should show the clear difference between both sets of (sync & future/promise) methods.
